### PR TITLE
Use slurm start_date to predict long wait jobs

### DIFF
--- a/queue_status.rb
+++ b/queue_status.rb
@@ -107,8 +107,10 @@ partitions.each do |partition, details|
   waiting = []
   details[:pending].each do |job|
     estimated_start = Time.parse(job[10]) rescue nil
-    wait = (estimated_start - Time.now) / 60.0 if estimated_start
-    wait = nil if wait > (300 * 24 * 60) if wait # ignore jobs due in a year
+    if estimated_start
+      wait = (estimated_start - Time.now) / 60.0
+      wait = wait > (300 * 24 * 60) ? nil : wait
+    end
     wait ||= (Time.now - Time.parse(job[7])) / 60.0
     if wait >= wait_threshold
       waiting << job


### PR DESCRIPTION
Uses slurms' estimated start time (`START_TIME`) for jobs to determine those predicted not to start within the defined `WAIT_THRESHOLD`
- Parses values for `START_TIME`, ignoring values of `N/A` or times 300 days or more in the future (as slurm sometimes decides that jobs with no time defined should take/ start in a year)
- This is checked against job submission time, and if the difference is greater than the value of `WAIT_THRESHOLD` the job is flagged as a 'long wait' job
- If `START_TIME` cannot be read, compares current time against submission time, in case this is already over the threshold
- Also adds display of jobs ids for long wait jobs and jobs where no resources available
- The accuracy/ existence of these estimates is dependent upon the use of explicit time limits, at job or partition level

<img src="https://user-images.githubusercontent.com/59840834/95356492-a16cc280-08be-11eb-99fc-b67072e460ca.png" width="600px">

