### PR TITLE
don't display mixed nodes multiple times

### DIFF
--- a/queue_status.rb
+++ b/queue_status.rb
@@ -65,6 +65,7 @@ end
 
 idle.uniq!
 allocated.uniq!
+mixed.uniq!
 down.uniq!
 
 # determine jobs, their status and partitions


### PR DESCRIPTION
For mixed nodes on more than one partition, only include them in totals once.

![Screenshot from 2020-10-09 17-01-59](https://user-images.githubusercontent.com/59840834/95605669-2e478580-0a51-11eb-96f8-f5dbcdcbfb2c.png)
