### PR TITLE
Multi partition jobs

### DIFF
--- a/queue_status.rb
+++ b/queue_status.rb
@@ -98,11 +98,11 @@ nodes.each do |node, queues|
   end
 end
 
-def disjunctive(list, spec, index)
+def duplicate_count(list, part, index)
   # Return a list of jobs on the given partition where each job exists in at least one other partition
 
   new = list.dup.tap { |l| l.delete_at(index) } # create copy of partitions list sans the current partition
-  unions = new.map { |p| p & spec } # find the union (&) of partition 'spec' with each other set in 'new'
+  unions = new.map { |p| p & part } # find the union (&) of partition 'part' with each other set in 'new'
   return unions.reduce(:|) # find the intersection (|) of the unions
 end
 
@@ -118,7 +118,7 @@ partitions.each_with_index do |(partition, details), index|
   partition_msg << "*Partition #{partition}*\n"
   partition_msg << "#{details[:running].length} job(s) running on partition #{partition}\n"
   partition_msg << "#{details[:pending].length} job(s) pending on partition #{partition}\n"
-  partition_msg << "#{disjunctive(all_pending_ids, all_pending_ids[index], index).length} of these pending jobs exist on at  least one other partition\n"
+  partition_msg << "#{duplicate_count(all_pending_ids, all_pending_ids[index], index).length} of these pending jobs exist on at least one other partition\n"
   # only calculate times if partition has resources, as otherwise we know jobs are stuck
   if details[:alive_nodes].any?
     waiting = []


### PR DESCRIPTION
This PR adds some handling for jobs that exist on multiple partition. The main change that has been made is a new line added to partition descriptions to show how many pending jobs are also pending on at least one other partition. Assuming the four partitions `[a,b,c,d]`, and we want to check partition `b`, this is done via the following steps:
- Create a copy of the list of partitions sans the partition being checked (`[a,c,d]`)
- Find the union of the checked partition with each of the other partitions (`[b & a, b & c, b & d]`)
- Find the intersection of the previously calculated unions `(b & a) | (b & c) | (b & d)`
- The resulting set is the set of jobs on partition `b` that also exist on at least one of `[a,c,d]`.

(The method that implements this is named `disjunct()`; while [disjunctive normal form](https://en.wikipedia.org/wiki/Disjunctive_normal_form) is technically in the realm of set theory, the definition is "a disjunction of conjunctions", or "an OR or ANDS", so I'm allowing it.)

The calculation of `total_pending` for partitions has also been made more accurate. The SLURM command used to print a list of jobs spits out superfluous entries when a job exists on multiple partitions, resulting in jobs being counted more than once. The new `total_pending` count is derived from the number of unique job IDs after all jobs have been accounted for.

