### PR TITLE
Highlight long running jobs

### DIFF
--- a/queue_status.rb
+++ b/queue_status.rb
@@ -242,7 +242,7 @@ partitions.each_with_index do |(partition, details), index|
 end
 
 [jobs_no_resources, total_long_waiting, total_long_running, total_cant_determine_wait].each do |list|
-  list.uniq!
+  list.uniq! { |job| job[1] }
   list.sort_by! { |job| job[1] }
 end
 no_start_data = total_cant_determine_wait.any? && total_cant_determine_wait.length == total_pending


### PR DESCRIPTION
Adds checks for jobs that have been running for a long time, as defined by the new environment variable `RUN_THRESHOLD`
- If this not set, defaults to 7 days (10080 minutes)
- Adds new method `formatted_threshold` for describing threshold values in a readable format (e.g. "12hrs 30m" or "7days")
- Ensures that lists of job ids are unique and sorted
- Adds more logic to only show extra details if there are running and/or pending jobs

**Simple Example:**
![Screenshot from 2020-10-12 16-09-20](https://user-images.githubusercontent.com/59840834/95763793-706a0480-0ca7-11eb-933b-d99e01cc3a45.png)

**Some jobs with times, some on multiple partitions:**
![Screenshot from 2020-10-12 16-16-51](https://user-images.githubusercontent.com/59840834/95763802-7364f500-0ca7-11eb-9501-cd1a64887895.png)
