### PR TITLE
Optionally display job ids for highlighted jobs

### DIFF
--- a/queue_status.rb
+++ b/queue_status.rb
@@ -241,7 +241,7 @@ msg = ["*#{Time.now.strftime("%F %T")}*\n",
        (": #{total_cant_determine_wait.map {|job| job[1] }.join(", ") }" if total_cant_determine_wait.any? && !no_start_data && show_ids),
        ("\nEstimated time all jobs completed: #{final_job_end}" if (total_running + total_pending) > 0 && final_job_end_valid),
        ("\nInsufficient data to estimate time all jobs completed" if (total_running + total_pending) > 0 && !final_job_end_valid),
-       (". Last known end time: #{final_job_end}" if final_job_end && !final_job_end_valid),
+       (". Latest known end time: #{final_job_end}" if final_job_end && !final_job_end_valid),
        "\n\n",
        partition_msg
 ].compact


### PR DESCRIPTION
Adds a new optional argument `ids`. If included, job ids will be shown for: long waiting jobs, jobs where start time can't be determined and jobs on partitions with no resources. If not included, no ids are displayed.

This will need to be updated to include long running jobs once PR #7 merged.

**Examples**
running `ruby queue_status.rb ids` 

![Screenshot from 2020-10-12 17-15-52](https://user-images.githubusercontent.com/59840834/95769198-6c41e500-0caf-11eb-8098-c97f4eec3b94.png)

running `ruby queue_status.rb`

![Screenshot from 2020-10-12 17-16-06](https://user-images.githubusercontent.com/59840834/95769540-f4c08580-0caf-11eb-93a9-d80b65ff86c8.png)

