### PR TITLE
Remove variable falsification

### DIFF
--- a/queue_status.rb
+++ b/queue_status.rb
@@ -227,6 +227,7 @@ partitions.each_with_index do |(partition, details), index|
 
   # highlight jobs with no resources
   else
+    final_job_end_valid = !(details[:pending].any? || details[:running].any?)
     partition_msg << ":awooga:Partition #{partition} has no available resources:awooga:\n"
     jobs = details[:running] + details[:pending]
     jobs.sort! { |job| job[1].to_i }


### PR DESCRIPTION
As far as my testing shows, this variable was setting `final_job_end_valid` to false whenever any partition had no available resources, which affected the overall estimation of job end times.

Resolves #10 when merged.