### PR TITLE
choose slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use this function, a [Slack bot](https://slack.com/apps/A0F7YS25R-bots) must 
 
 `SLACK_TOKEN=yourtoken ruby -e 'p ENV["SLACK_TOKEN"]'`
 
-The created bot must be a member of the Slack channel you wish to post it in.
+The Slack channel you wish to post to must be set as the environment variable `SLACK_CHANNEL`. The created bot must be a member of this Slack channel.
 
 ### Thresholds
 

--- a/queue_status.rb
+++ b/queue_status.rb
@@ -29,7 +29,7 @@ require 'time'
 require 'httparty'
 
 def send_slack_message(msg)
-  HTTParty.post("https://slack.com/api/chat.postMessage", headers: {"Authorization": "Bearer #{ENV['SLACK_TOKEN']}"}, body: {"text": msg, "channel": "tim-test", "as_user": true})
+  HTTParty.post("https://slack.com/api/chat.postMessage", headers: {"Authorization": "Bearer #{ENV['SLACK_TOKEN']}"}, body: {"text": msg, "channel": ENV['SLACK_CHANNEL'], "as_user": true})
 end
 
 def wait_threshold


### PR DESCRIPTION
Aims to resolve #12 

- Slack channel no longer hard coded and can now be set using the environment variable `SLACK_CHANNEL`
- Readme updated to reflect this