### PR TITLE
Don't hardcode SLURM path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ bundle install
 
 ## Configuration
 
+### PATH environment
+
+This application assumes that your instance of SLURM is set up properly in your PATH environment variable(s). Please ensure that SLURM is accessible by name at the command line (e.g. `sinfo -Nl` should return a list of all nodes and partitions).
+
 ### Slack
 
 This application has the functionality to post any report outputs to Slack, as well as the command line.

--- a/queue_status.rb
+++ b/queue_status.rb
@@ -62,13 +62,13 @@ show_ids = ARGV.include?("ids")
 
 # determine partitions
 partitions = {}
-data = %x(/opt/flight/opt/slurm/bin/sinfo p)
+data = %x(sinfo p)
 result = data.gsub("*", "").split("\n")
 result.shift
 result.each { |partition| partitions[partition.split(" ")[0]] = {running: [], pending: [], alive_nodes: [], dead_nodes: []} }
 
 # determine nodes, their status and their partitions
-data = %x(/opt/flight/opt/slurm/bin/sinfo -Nl)
+data = %x(sinfo -Nl)
 result = data.split("\n")
 result.shift(2)
 nodes = {}
@@ -91,7 +91,7 @@ result.each do |node|
 end
 
 # determine unresponsive nodes
-data = %x(/opt/flight/opt/slurm/bin/sinfo -Nl --dead)
+data = %x(sinfo -Nl --dead)
 result = data.split("\n")
 result.shift(2)
 down = []
@@ -112,7 +112,7 @@ mixed.uniq!
 down.uniq!
 
 # determine jobs, their status and partitions
-data =  %x(/opt/flight/opt/slurm/bin/squeue -o '%j %A %D %c %m %T %P %V %L %l %S %e %r' --priority)
+data =  %x(squeue -o '%j %A %D %c %m %T %P %V %L %l %S %e %r' --priority)
 total_running = 0
 result = data.split("\n")
 result.shift


### PR DESCRIPTION
After a brief discussion on [user responsibility](https://github.com/openflighthpc/queue-status-reporter/issues/15#issuecomment-710111792), it was decided that the application should run assuming that the user has set up their PATH environment variable properly.

When calling any of the SLURM commands in the program, they are now executed relatively by name, instead of calling an absolute path.

Resolves #15 when merged.